### PR TITLE
updates to be able to run on arm64 cpu (like apple m1)

### DIFF
--- a/generic-images/nginx-php/Dockerfile
+++ b/generic-images/nginx-php/Dockerfile
@@ -1,4 +1,4 @@
-FROM webreactor/ubuntu:14.04.03
+FROM webreactor/ubuntu:20.04.01
 
 # htdocs folder: /var/www
 

--- a/generic-images/nginx-php/Makefile
+++ b/generic-images/nginx-php/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME=webreactor/nginx-php
-IMAGE_TAG=v0.0.3
+IMAGE_TAG=v0.0.4
 IMAGE=$(IMAGE_NAME):$(IMAGE_TAG)
 
 build:

--- a/generic-images/nginx-php/install.sh
+++ b/generic-images/nginx-php/install.sh
@@ -4,27 +4,10 @@ set -e -v
 
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-locale-gen $LC_ALL
-
-apt-get update
-
-apt-get install -y --no-install-recommends \
-    git \
-    curl \
-    wget \
-    vim \
-    ca-certificates \
-    software-properties-common \
-    make
-
-
-
-
-add-apt-repository -y ppa:nginx/development
+#add-apt-repository -y ppa:nginx/development
 add-apt-repository -y ppa:ondrej/php
 
-apt-get -y update
-apt-get install -y --no-install-recommends \
+apt-get -y update && apt-get install -y --no-install-recommends \
     nginx \
     php7.2-fpm \
     php7.2-cli \
@@ -49,6 +32,9 @@ apt-get install -y --no-install-recommends \
 php -r "readfile('https://getcomposer.org/installer');" | php
 mv composer.phar /usr/bin/composer
 
+# временно даунгрейдимся до версии 1, т.к. для 2 нужно поправить имена пакетов
+composer self-update 1.10.16
+
 curl -L https://github.com/webreactor/db-migration/releases/download/1.0.2/db-migration > /usr/local/bin/db-migration
 chmod a+x /usr/local/bin/db-migration
 
@@ -62,9 +48,9 @@ cp ./nginx/nginx.conf      /etc/nginx/nginx.conf
 
 cp ./php/owerride*.ini     /etc/php/5.6/mods-available/
 cp ./php/www.conf          /etc/php/5.6/fpm/pool.d/www.conf
-phpenmod -s cli owerride-php-cli
+phpenmod -v 5.6 -s cli owerride-php-cli
 
-cp ./nxlog/patterndb.xml   /etc/nxlog/patterndb/patterndb.xml
+cp ./nxlog/patterndb.xml   /usr/local/etc/nxlog/patterndb/patterndb.xml
 
 cp ./php/start-php-fpm /usr/local/bin
 cp ./start-nginx-php-nxlog /usr/local/bin

--- a/generic-images/ubuntu/Dockerfile
+++ b/generic-images/ubuntu/Dockerfile
@@ -1,9 +1,14 @@
-FROM ubuntu:14.04
-
-RUN sudo locale-gen en_US.UTF-8 && sudo update-locale LANG=en_US.UTF-8
-
-ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 TERM=xterm
+FROM ubuntu:20.04
 
 ADD . /opt/base-image/
 
+RUN apt-get update && apt-get install -y locales
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
+
+ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 TERM=xterm
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Minsk
+
 RUN /opt/base-image/install.sh
+RUN /opt/base-image/build-nxlog.sh

--- a/generic-images/ubuntu/Makefile
+++ b/generic-images/ubuntu/Makefile
@@ -1,10 +1,10 @@
 IMAGE_NAME=webreactor/ubuntu
-IMAGE_TAG=14.04.03
+IMAGE_TAG=20.04.01
 IMAGE=$(IMAGE_NAME):$(IMAGE_TAG)
 
 build:
 	docker build -t $(IMAGE) .
-	docker tag -f $(IMAGE) $(IMAGE_NAME):latest
+	docker tag $(IMAGE) $(IMAGE_NAME):latest
 
 push:
 	docker push $(IMAGE)

--- a/generic-images/ubuntu/build-nxlog.sh
+++ b/generic-images/ubuntu/build-nxlog.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+apt-get update && apt-get install -y \
+  build-essential \
+  libapr1-dev \
+  libpcre3-dev \
+  libssl-dev \
+  libexpat1-dev
+
+mkdir /root/nxlog
+pushd /root/nxlog
+wget https://nxlog.co/system/files/products/files/348/nxlog-ce-2.11.2190.tar.gz
+tar zxkf nxlog-ce-2.11.2190.tar.gz
+cd nxlog-ce-2.11.13
+./configure && make && make install && echo "nxlog has build ok"
+popd

--- a/generic-images/ubuntu/install.sh
+++ b/generic-images/ubuntu/install.sh
@@ -16,20 +16,19 @@ apt-get install -y --no-install-recommends \
     ca-certificates \
     supervisor \
     software-properties-common \
-    make
+    make \
+    less \
+    netcat \
+    python
 
 apt-get install -y --no-install-recommends \
-    libapr1 libdbi1 libperl5.18
+    libapr1 libdbi1 libperl5.30
 
-curl -k -L https://nxlog.co/system/files/products/files/1/nxlog-ce_2.9.1716_ubuntu_1404_amd64.deb -o nxlog.deb
-dpkg -i nxlog.deb
-apt-get -f -y install
-
-mkdir -p /etc/nxlog/conf.d/ /etc/nxlog/patterndb/
-cp ./nxlog/nxlog.conf      /etc/nxlog/nxlog.conf
-cp ./nxlog/json-server.conf.tpl /etc/nxlog/json-server.conf.tpl
-cp ./nxlog/docker-log.conf /etc/nxlog/conf.d/docker-log.conf
-cp ./nxlog/patterndb.xml   /etc/nxlog/patterndb/patterndb.xml
+mkdir -p /usr/local/etc/nxlog/conf.d/ /usr/local/etc/nxlog/patterndb/
+cp ./nxlog/nxlog.conf      /usr/local/etc/nxlog/nxlog.conf
+cp ./nxlog/json-server.conf.tpl /usr/local/etc/nxlog/json-server.conf.tpl
+cp ./nxlog/docker-log.conf /usr/local/etc/nxlog/conf.d/docker-log.conf
+cp ./nxlog/patterndb.xml   /usr/local/etc/nxlog/patterndb/patterndb.xml
 cp ./nxlog/start-nxlog /usr/local/bin/
 
 curl -L https://raw.githubusercontent.com/webreactor/wait-for-service/master/wait-for-service > /usr/local/bin/wait-for-service

--- a/generic-images/ubuntu/nxlog/docker-log.conf
+++ b/generic-images/ubuntu/nxlog/docker-log.conf
@@ -1,7 +1,7 @@
 
 <Processor pdb-docker-log>
     Module      pm_pattern
-    PatternFile /etc/nxlog/patterndb/patterndb.xml
+    PatternFile /usr/local/etc/nxlog/patterndb/patterndb.xml
 </Processor>
 
 <Output docker-log>

--- a/generic-images/ubuntu/nxlog/nxlog.conf
+++ b/generic-images/ubuntu/nxlog/nxlog.conf
@@ -1,3 +1,4 @@
+PidFile /var/run/nxlog.pid
 FlowControl false
 LogFile /var/log/nxlog.log
 LogLevel INFO
@@ -10,8 +11,8 @@ LogLevel INFO
     Module  xm_syslog
 </Extension>
 
-include /etc/nxlog/env*.conf
-include /etc/nxlog/conf.d/*.conf
+include /usr/local/etc/nxlog/env*.conf
+include /usr/local/etc/nxlog/conf.d/*.conf
 
 <Input syslog>
     Module  im_uds

--- a/generic-images/ubuntu/nxlog/start-nxlog
+++ b/generic-images/ubuntu/nxlog/start-nxlog
@@ -3,7 +3,7 @@
 MARATHON_APP_ID=${MARATHON_APP_ID:-false} \
 PRETTY_LOG=${PRETTY_LOG:-false} \
 DISABLE_INFO=${DISABLE_INFO:-false} \
-env | grep -v :container | sed -n -r 's/(\w+)=(.+)/define ENV_\1 \2/p' > "/etc/nxlog/env.conf"
+env | grep -v :container | sed -n -r 's/(\w+)=(.+)/define ENV_\1 \2/p' > "/usr/local/etc/nxlog/env.conf"
 
 if [ -n "$DISABLE_DOCKER_LOG" ]; then
     rm /etc/nxlog/conf.d/docker-log.conf

--- a/generic-images/ubuntu/start-nxlog
+++ b/generic-images/ubuntu/start-nxlog
@@ -3,7 +3,7 @@
 MARATHON_APP_ID=${MARATHON_APP_ID:-false} \
 PRETTY_LOG=${PRETTY_LOG:-false} \
 DISABLE_INFO=${DISABLE_INFO:-false} \
-env | grep -v :container | sed -n -r 's/(\w+)=(.+)/define ENV_\1 \2/p' > "/etc/nxlog/env.conf"
+env | grep -v :container | sed -n -r 's/(\w+)=(.+)/define ENV_\1 \2/p' > "/usr/local/etc/nxlog/env.conf"
 
 if [ -n "$DISABLE_DOCKER_LOG" ]; then
     rm /etc/nxlog/conf.d/docker-log.conf


### PR DESCRIPTION
Changes:
- ubuntu updated to 20.04
- nxlog is built from source because there's no nxlog package for arm64 architecture.

alternate nxlog source code download: https://drive.google.com/file/d/1PyiIiggEdj2mZUxfUIo5ytukKoGJhwBG/view?usp=sharing